### PR TITLE
fix: `NullReferenceException` when loding mod config

### DIFF
--- a/HammersRingingFall/HammersRingingFall.cs
+++ b/HammersRingingFall/HammersRingingFall.cs
@@ -16,6 +16,8 @@ namespace HammersRingingFall
             try
             {
                 var Config = api.LoadModConfig<HammersRingingFallConfig>("hammersringingfall.json");
+                if (Config is null) throw new FileNotFoundException();
+
                 api.Logger.Notification("HRF Mod Config Succcessfully Loaded.");
                 HammersRingingFallConfig.Current = Config;
             }

--- a/HammersRingingFall/changelog.txt
+++ b/HammersRingingFall/changelog.txt
@@ -1,3 +1,6 @@
+1.2.3
+	- Fixed current config assignment
+
 1.2.2
 	- Fixed Stone Quarry Tools Compat
 	- Correct Recipe Output for hinges

--- a/HammersRingingFall/modinfo.json
+++ b/HammersRingingFall/modinfo.json
@@ -4,7 +4,7 @@
   "name": "Hammers Ringing Fall",
   "authors": [ "Vinter Nacht","Percival", "Raccoon", "WesCookie"],
   "description": "With measured beat and slow, Like a sexton ringing the village bell - Henry Wadsworh Longfellow",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "dependencies": {
     "game": ""
   }


### PR DESCRIPTION
Hi @VinterNacht, 

Shoujiro here. This PR contains a fix for 1.17. I think updated everything that needs to be updated but you still need to compile the mod. I couldn't make your environment work, so I repackaged everything to make it work locally for me. You will need to update assembly references to make them point to the 1.17 version but everything else should be good to go. Let me know if you need anything else.

Why
---
- When the mod config does not exist `LoadModConfig` returns null, which then gets assigned to `HammersRingingFallConfig.Current`, which in turn causes `NullReferenceException` when accessed

How
---
- By explicitly doing a null check and throwing `FileNotFoundException`